### PR TITLE
Add support for java.time.Duration

### DIFF
--- a/src/main/java/org/zalando/baigan/proxy/handler/ContextAwareConfigurationMethodInvocationHandler.java
+++ b/src/main/java/org/zalando/baigan/proxy/handler/ContextAwareConfigurationMethodInvocationHandler.java
@@ -18,6 +18,7 @@ import org.zalando.baigan.service.ConfigurationRepository;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -92,6 +93,8 @@ public class ContextAwareConfigurationMethodInvocationHandler
                 }
                 LOG.warn("Unable to map [{}] to enum type [{}].", result, declaredReturnType.getName());
                 return null;
+            } else if (declaredReturnType.equals(Duration.class) && result instanceof String) {
+                return Duration.parse((String)result);
             } else {
                 constructor = declaredReturnType
                         .getDeclaredConstructor(result.getClass());

--- a/src/test/java/org/zalando/baigan/context/MethodInvocationHandlerTest.java
+++ b/src/test/java/org/zalando/baigan/context/MethodInvocationHandlerTest.java
@@ -11,6 +11,7 @@ import org.zalando.baigan.service.ConditionsProcessor;
 import org.zalando.baigan.service.ConfigurationRepository;
 
 import java.lang.reflect.InvocationHandler;
+import java.time.Duration;
 import java.util.Optional;
 
 import static com.google.common.collect.ImmutableSet.of;
@@ -37,6 +38,8 @@ interface Express extends Base {
     State stateDefault();
 
     int maxDeliveryDays();
+
+    Duration notificationDelay();
 }
 
 /**
@@ -84,6 +87,19 @@ public class MethodInvocationHandlerTest {
 
         Object object = invokeHandler(handler, Express.class, "maxDeliveryDays");
         assertThat(object, Matchers.equalTo(3));
+    }
+
+    @Test
+    public void testDurationType() throws Throwable {
+
+        final ConfigurationRepository repo = mock(ConfigurationRepository.class);
+        final Configuration<String> configuration = new Configuration<>("express.notification.delay", DESCRIPTION, of(), "PT5m");
+        when(repo.get(anyString())).thenReturn(Optional.of(configuration));
+
+        final ContextAwareConfigurationMethodInvocationHandler handler = createHandler(repo);
+
+        Object object = invokeHandler(handler, Express.class, "notificationDelay");
+        assertThat(object, Matchers.equalTo(Duration.ofMinutes(5)));
     }
 
     @Test


### PR DESCRIPTION
This PR adds support for `java.time.Duration` as a configuration parameter type.
A workaround solution could be to use a `String` parameter instead and parse it on the application level, but it's not very convenient and readable.