### PR TITLE
updating dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,14 +38,14 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jackson.version>2.6.1</jackson.version>
-        <junit.version>4.11</junit.version>
-        <spring.version>4.2.1.RELEASE</spring.version>
-        <guava.version>18.0</guava.version>
-        <slf4j.version>1.7.12</slf4j.version>
-        <mockito.version>1.10.19</mockito.version>
-        <hamcrest.version>1.3</hamcrest.version>
-        <awssdk.version>1.11.25</awssdk.version>
+        <jackson.version>2.15.1</jackson.version>
+        <junit.version>5.9.3</junit.version>
+        <spring.version>5.3.27</spring.version>
+        <guava.version>31.1-jre</guava.version>
+        <slf4j.version>2.0.7</slf4j.version>
+        <mockito.version>5.3.1</mockito.version>
+        <hamcrest.version>2.2</hamcrest.version>
+        <awssdk.version>1.12.475</awssdk.version>
     </properties>
 
     <dependencyManagement>
@@ -79,7 +79,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.18.1</version>
+                    <version>3.1.2</version>
                     <configuration>
                         <forkCount>0</forkCount>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
@@ -88,15 +88,15 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.17</version>
+                    <version>3.1.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.2</version>
+                    <version>3.11.0</version>
                     <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
+                        <source>11</source>
+                        <target>11</target>
                     </configuration>
                 </plugin>
             </plugins>
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.2</version>
         </dependency>
 
         <dependency>
@@ -169,7 +169,7 @@
         <dependency>
             <groupId>net.jodah</groupId>
             <artifactId>failsafe</artifactId>
-            <version>2.2.0</version>
+            <version>2.4.4</version>
         </dependency>
 
         <dependency>
@@ -181,13 +181,19 @@
         <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
-            <version>0.9.10</version>
+            <version>0.10.2</version>
         </dependency>
 
         <!-- Test dependencies -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
@@ -200,7 +206,13 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
@@ -221,7 +233,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.10.3</version>
+                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -237,7 +249,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>2.2.1</version>
+                        <version>3.3.0</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -250,7 +262,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
+                        <version>3.1.0</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/src/test/java/org/zalando/baigan/TestConfigurationSerialization.java
+++ b/src/test/java/org/zalando/baigan/TestConfigurationSerialization.java
@@ -16,31 +16,22 @@
 
 package org.zalando.baigan;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-import java.util.Set;
-
-import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.zalando.baigan.model.Condition;
 import org.zalando.baigan.model.Configuration;
 import org.zalando.baigan.model.Equals;
 import org.zalando.baigan.service.ConditionsProcessor;
 
-import com.fasterxml.jackson.core.JsonGenerationException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
+import java.util.Set;
 
-@RunWith(JUnit4.class)
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 public class TestConfigurationSerialization {
 
     private ObjectMapper mapper;
@@ -50,9 +41,8 @@ public class TestConfigurationSerialization {
     private final String stringy = "{\"alias\":\"express.feature.toggle\",\"description\":\"Feature toggle\",\"conditions\":"
             + "[{\"paramName\":\"appdomain\",\"conditionType\":{\"type\":\"Equals\",\"onValue\":\"1\"},\"value\":true}],\"defaultValue\":false}";
 
-    @Before
-    public void init()
-            throws JsonMappingException, JsonGenerationException, IOException {
+    @BeforeEach
+    public void init() {
         mapper = new ObjectMapper().registerModule(new GuavaModule());
         conditionsProcessor = new ConditionsProcessor();
 
@@ -70,11 +60,11 @@ public class TestConfigurationSerialization {
 
     private void testConfigurationTrueOnlyForAppdomain1(
             final Configuration<Boolean> paramConfiguration) {
-        assertTrue(conditionsProcessor.process(paramConfiguration,
-                ImmutableMap.of("appdomain", "1")));
+        assertThat(conditionsProcessor.process(paramConfiguration,
+                ImmutableMap.of("appdomain", "1")), equalTo(true));
 
-        assertFalse(conditionsProcessor.process(paramConfiguration,
-                ImmutableMap.of("appdomain", "2")));
+        assertThat(conditionsProcessor.process(paramConfiguration,
+                ImmutableMap.of("appdomain", "2")), equalTo(false));
     }
 
     @Test
@@ -96,7 +86,7 @@ public class TestConfigurationSerialization {
     public void testSerialize() throws Exception {
         final Configuration config = createConfigurationForAppdomain1();
         final String serialized = mapper.writeValueAsString(config);
-        assertThat(serialized, Matchers.equalTo(stringy));
+        assertThat(serialized, equalTo(stringy));
     }
 
 }

--- a/src/test/java/org/zalando/baigan/TestEtcdConfigService.java
+++ b/src/test/java/org/zalando/baigan/TestEtcdConfigService.java
@@ -16,30 +16,24 @@
 
 package org.zalando.baigan;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-import java.io.StringWriter;
-import java.util.Set;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.zalando.baigan.model.Condition;
 import org.zalando.baigan.model.Configuration;
 import org.zalando.baigan.model.Equals;
 import org.zalando.baigan.service.ConditionsProcessor;
 
-import com.fasterxml.jackson.core.JsonGenerationException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Set;
 
-@RunWith(JUnit4.class)
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
 public class TestEtcdConfigService {
 
     private final static ObjectMapper mapper = new ObjectMapper()
@@ -49,9 +43,8 @@ public class TestEtcdConfigService {
 
     private String buffer = null;
 
-    @Before
-    public void init()
-            throws JsonMappingException, JsonGenerationException, IOException {
+    @BeforeEach
+    public void init() throws IOException {
 
         final Condition<Boolean> condition = new Condition<Boolean>("appdomain",
                 new Equals("1"), true);
@@ -69,11 +62,11 @@ public class TestEtcdConfigService {
 
         final ConditionsProcessor conditionsProcessor = new ConditionsProcessor();
 
-        assertTrue(conditionsProcessor.process(configuration,
-                ImmutableMap.of("appdomain", "1")));
+        assertThat(conditionsProcessor.process(configuration,
+                ImmutableMap.of("appdomain", "1")), equalTo(true));
 
-        assertFalse(conditionsProcessor.process(configuration,
-                ImmutableMap.of("appdomain", "2")));
+        assertThat(conditionsProcessor.process(configuration,
+                ImmutableMap.of("appdomain", "2")), equalTo(false));
     }
 
     @Test

--- a/src/test/java/org/zalando/baigan/context/ConfigurationBeanDefinitionRegistrarTest.java
+++ b/src/test/java/org/zalando/baigan/context/ConfigurationBeanDefinitionRegistrarTest.java
@@ -16,12 +16,8 @@
 
 package org.zalando.baigan.context;
 
-import static org.junit.Assert.assertThat;
-
-import org.hamcrest.Matchers;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
@@ -32,14 +28,15 @@ import org.zalando.baigan.annotation.BaiganConfig;
 import org.zalando.baigan.annotation.ConfigurationServiceScan;
 import org.zalando.baigan.proxy.ConfigurationBeanDefinitionRegistrar;
 
-import com.google.common.collect.ImmutableMap;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  *
  * @author mchand
  *
  */
-@RunWith(JUnit4.class)
 public class ConfigurationBeanDefinitionRegistrarTest {
 
     @Test
@@ -67,11 +64,10 @@ public class ConfigurationBeanDefinitionRegistrarTest {
         Mockito.verify(registry).registerBeanDefinition(beanName.capture(),
                 beanDefinition.capture());
 
-        assertThat(beanName.getValue(), Matchers.equalTo(
+        assertThat(beanName.getValue(), equalTo(
                 "org.zalando.baigan.context.SuperSonicBaiganProxyConfigurationFactoryBean"));
 
-        assertThat(beanDefinition.getValue(),
-                Matchers.instanceOf(GenericBeanDefinition.class));
+        assertThat(beanDefinition.getValue(), instanceOf(GenericBeanDefinition.class));
 
     }
 

--- a/src/test/java/org/zalando/baigan/context/ConfigurationContextProvisionIT.java
+++ b/src/test/java/org/zalando/baigan/context/ConfigurationContextProvisionIT.java
@@ -16,33 +16,27 @@
 
 package org.zalando.baigan.context;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.zalando.baigan.context.ConfigurationContextProvisionIT.StaticAppdomainProvider;
+import org.zalando.baigan.provider.ContextProvider;
 
 import java.util.Collection;
 import java.util.Set;
 
-import org.hamcrest.Matchers;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.zalando.baigan.context.ConfigurationContext;
-import org.zalando.baigan.context.ConfigurationContextProviderBeanPostprocessor;
-import org.zalando.baigan.context.ConfigurationContextProviderRegistryImpl;
-import org.zalando.baigan.context.ContextProviderRetriever;
-import org.zalando.baigan.context.ConfigurationContextProvisionIT.StaticAppdomainProvider;
-import org.zalando.baigan.provider.ContextProvider;
-
-import com.google.common.collect.ImmutableSet;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  *
  * @author Mohammed Amjed
  *
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = { StaticAppdomainProvider.class,
         ConfigurationContextProviderRegistryImpl.class,
         ConfigurationContextProviderBeanPostprocessor.class })
@@ -62,7 +56,7 @@ public class ConfigurationContextProvisionIT {
 
         final String contextValue = contextProviders.iterator().next()
                 .getContextParam(contextParam);
-        assertThat(contextValue, Matchers.equalTo("1"));
+        assertThat(contextValue, equalTo("1"));
     }
 
     static class StaticAppdomainProvider implements ContextProvider {

--- a/src/test/java/org/zalando/baigan/context/MethodInvocationHandlerTest.java
+++ b/src/test/java/org/zalando/baigan/context/MethodInvocationHandlerTest.java
@@ -1,9 +1,6 @@
 package org.zalando.baigan.context;
 
-import org.hamcrest.Matchers;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanFactory;
 import org.zalando.baigan.model.Configuration;
 import org.zalando.baigan.proxy.handler.ContextAwareConfigurationMethodInvocationHandler;
@@ -15,10 +12,11 @@ import java.util.Optional;
 
 import static com.google.common.collect.ImmutableSet.of;
 import static com.google.common.reflect.Reflection.newProxy;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -42,7 +40,6 @@ interface Express extends Base {
 /**
  * @author mchand
  */
-@RunWith(JUnit4.class)
 public class MethodInvocationHandlerTest {
 
     private static final String DESCRIPTION = "This is a test configuration object.";
@@ -57,7 +54,7 @@ public class MethodInvocationHandlerTest {
         final ContextAwareConfigurationMethodInvocationHandler handler = createHandler(repo);
 
         Object object = invokeHandler(handler, Express.class, "stateDefault");
-        assertThat(object, Matchers.equalTo(State.SHIPPING));
+        assertThat(object, equalTo(State.SHIPPING));
     }
 
     @Test
@@ -83,7 +80,7 @@ public class MethodInvocationHandlerTest {
         final ContextAwareConfigurationMethodInvocationHandler handler = createHandler(repo);
 
         Object object = invokeHandler(handler, Express.class, "maxDeliveryDays");
-        assertThat(object, Matchers.equalTo(3));
+        assertThat(object, equalTo(3));
     }
 
     @Test

--- a/src/test/java/org/zalando/baigan/context/TestConfigurationContextProviderBeanPostProcessor.java
+++ b/src/test/java/org/zalando/baigan/context/TestConfigurationContextProviderBeanPostProcessor.java
@@ -16,14 +16,15 @@
 
 package org.zalando.baigan.context;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.zalando.baigan.provider.ContextProvider;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -31,7 +32,7 @@ import static org.mockito.Mockito.verify;
 /**
  * @author mchand
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class TestConfigurationContextProviderBeanPostProcessor {
 
     private final ContextProvider provider = mock(ContextProvider.class);
@@ -48,7 +49,7 @@ public class TestConfigurationContextProviderBeanPostProcessor {
                 .forClass(ContextProvider.class);
 
         verify(registry, times(1))
-                .register(org.mockito.Matchers.any(ContextProvider.class));
+                .register(any(ContextProvider.class));
 
         verify(registry).register(contextProviderCaptor.capture());
         assertThat(contextProviderCaptor.getValue(), equalTo(provider));

--- a/src/test/java/org/zalando/baigan/context/TestConfigurationContextProviderRegistryImpl.java
+++ b/src/test/java/org/zalando/baigan/context/TestConfigurationContextProviderRegistryImpl.java
@@ -16,26 +16,24 @@
 
 package org.zalando.baigan.context;
 
-import static org.junit.Assert.assertEquals;
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.zalando.baigan.provider.ContextProvider;
 
 import java.util.Collection;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
-import org.zalando.baigan.context.ConfigurationContext;
-import org.zalando.baigan.context.ConfigurationContextProviderRegistryImpl;
-import org.zalando.baigan.provider.ContextProvider;
-
-import com.google.common.collect.ImmutableSet;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 
 /**
  *
  * @author mchand
  *
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class TestConfigurationContextProviderRegistryImpl {
 
     final String TEST_CONTEXT_PARAM_VALUE = "99";
@@ -56,12 +54,12 @@ public class TestConfigurationContextProviderRegistryImpl {
 
         final Collection<ContextProvider> providers = registry
                 .getProvidersFor(ConfigurationContext.APPDOMAIN.name());
-        assertEquals(1, providers.size());
+        assertThat(providers.size(), equalTo(1));
         final ContextProvider provider = providers.iterator().next();
 
         final String contextParamValue = provider
                 .getContextParam(ConfigurationContext.APPDOMAIN.name());
-        assertEquals(TEST_CONTEXT_PARAM_VALUE, contextParamValue);
+        assertThat(contextParamValue, equalTo(TEST_CONTEXT_PARAM_VALUE));
 
     }
 }

--- a/src/test/java/org/zalando/baigan/model/TestEndsWith.java
+++ b/src/test/java/org/zalando/baigan/model/TestEndsWith.java
@@ -16,16 +16,12 @@
 
 package org.zalando.baigan.model;
 
-import static org.junit.Assert.assertThat;
-
-import org.hamcrest.Matchers;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.Test;
 
-@RunWith(JUnit4.class)
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 public class TestEndsWith {
 
     @Test
@@ -37,10 +33,10 @@ public class TestEndsWith {
         final ConditionType conditionType = new EndsWith(
                 ImmutableSet.of("gmx.de", "zalando.uk"));
 
-        assertThat(conditionType.eval(bar), Matchers.equalTo(false));
-        assertThat(conditionType.eval(gmx), Matchers.equalTo(true));
-        assertThat(conditionType.eval(bazinga), Matchers.equalTo(false));
-        assertThat(conditionType.eval(sally), Matchers.equalTo(true));
+        assertThat(conditionType.eval(bar), equalTo(false));
+        assertThat(conditionType.eval(gmx), equalTo(true));
+        assertThat(conditionType.eval(bazinga), equalTo(false));
+        assertThat(conditionType.eval(sally), equalTo(true));
 
     }
 }

--- a/src/test/java/org/zalando/baigan/model/TestEquals.java
+++ b/src/test/java/org/zalando/baigan/model/TestEquals.java
@@ -16,14 +16,11 @@
 
 package org.zalando.baigan.model;
 
-import static org.junit.Assert.assertThat;
+import org.junit.jupiter.api.Test;
 
-import org.hamcrest.Matchers;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-@RunWith(JUnit4.class)
 public class TestEquals {
 
     @Test
@@ -33,10 +30,10 @@ public class TestEquals {
         final String other = "baz@bar.com";
         final ConditionType conditionType = new Equals(email);
 
-        assertThat(conditionType.eval(other), Matchers.equalTo(false));
-        assertThat(conditionType.eval(email), Matchers.equalTo(true));
+        assertThat(conditionType.eval(other), equalTo(false));
+        assertThat(conditionType.eval(email), equalTo(true));
 
-        assertThat(conditionType.eval(otherCase), Matchers.equalTo(true));
+        assertThat(conditionType.eval(otherCase), equalTo(true));
 
     }
 }

--- a/src/test/java/org/zalando/baigan/model/TestIn.java
+++ b/src/test/java/org/zalando/baigan/model/TestIn.java
@@ -16,16 +16,12 @@
 
 package org.zalando.baigan.model;
 
-import static org.junit.Assert.assertThat;
-
-import org.hamcrest.Matchers;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.Test;
 
-@RunWith(JUnit4.class)
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 public class TestIn {
 
     @Test
@@ -38,10 +34,10 @@ public class TestIn {
         final ConditionType conditionType = new In(
                 ImmutableSet.of("1", "3", "7"));
 
-        assertThat(conditionType.eval(one), Matchers.equalTo(true));
-        assertThat(conditionType.eval(three), Matchers.equalTo(true));
+        assertThat(conditionType.eval(one), equalTo(true));
+        assertThat(conditionType.eval(three), equalTo(true));
 
-        assertThat(conditionType.eval(eight), Matchers.equalTo(false));
+        assertThat(conditionType.eval(eight), equalTo(false));
 
     }
 }

--- a/src/test/java/org/zalando/baigan/proxy/ConfigurationServiceBeanFactoryIT.java
+++ b/src/test/java/org/zalando/baigan/proxy/ConfigurationServiceBeanFactoryIT.java
@@ -1,7 +1,7 @@
 package org.zalando.baigan.proxy;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
@@ -12,7 +12,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.zalando.baigan.BaiganSpringContext;
 import org.zalando.baigan.annotation.BaiganConfig;
 import org.zalando.baigan.annotation.ConfigurationServiceScan;
@@ -21,12 +21,12 @@ import org.zalando.baigan.service.ConfigurationRepository;
 import org.zalando.baigan.service.github.GitConfig;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {ConfigurationServiceBeanFactoryIT.TestContext.class})
 public class ConfigurationServiceBeanFactoryIT {
 

--- a/src/test/java/org/zalando/baigan/service/FileSystemConfigurationRepositoryTest.java
+++ b/src/test/java/org/zalando/baigan/service/FileSystemConfigurationRepositoryTest.java
@@ -1,18 +1,15 @@
 package org.zalando.baigan.service;
 
-import org.hamcrest.Matchers;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-@RunWith(BlockJUnit4ClassRunner.class)
 public class FileSystemConfigurationRepositoryTest {
 
     @Test
     public void testReadConfigurationsFromFile() {
         final ConfigurationRepository repo = new FileSystemConfigurationRepository(3, "src/test/resources/example.json");
-        assertThat(repo.get("express.feature.toggle").get().getDefaultValue(), Matchers.equalTo(false));
+        assertThat(repo.get("express.feature.toggle").get().getDefaultValue(), equalTo(false));
     }
 }

--- a/src/test/java/org/zalando/baigan/service/TestConditionsProcessor.java
+++ b/src/test/java/org/zalando/baigan/service/TestConditionsProcessor.java
@@ -16,24 +16,20 @@
 
 package org.zalando.baigan.service;
 
-import static org.junit.Assert.assertThat;
-
-import java.util.Map;
-import java.util.Set;
-
-import org.hamcrest.Matchers;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.Test;
 import org.zalando.baigan.model.Condition;
 import org.zalando.baigan.model.Configuration;
 import org.zalando.baigan.model.EndsWith;
 import org.zalando.baigan.model.In;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
+import java.util.Map;
+import java.util.Set;
 
-@RunWith(JUnit4.class)
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 public class TestConditionsProcessor {
 
     private static final String NONE = "NONE";
@@ -52,17 +48,17 @@ public class TestConditionsProcessor {
         final Map<String, String> context1 = ImmutableMap.of(APPDOMAIN, "1",
                 CUSTOMER_NUMBER, "1239");
         assertThat(processor.process(configuration, context1),
-                Matchers.equalTo(true));
+                equalTo(true));
 
         final Map<String, String> context2 = ImmutableMap.of(APPDOMAIN, "4",
                 CUSTOMER_NUMBER, "5712");
         assertThat(processor.process(configuration, context2),
-                Matchers.equalTo(true));
+                equalTo(true));
 
         final Map<String, String> context3 = ImmutableMap.of(APPDOMAIN, "6",
                 CUSTOMER_NUMBER, "5718");
         assertThat(processor.process(configuration, context3),
-                Matchers.equalTo(false));
+                equalTo(false));
 
     }
 
@@ -76,11 +72,11 @@ public class TestConditionsProcessor {
 
         final Map<String, String> context1 = ImmutableMap.of(APPDOMAIN, "1");
         assertThat(processor.process(configuration, context1),
-                Matchers.equalTo(DHL));
+                equalTo(DHL));
 
         final Map<String, String> context2 = ImmutableMap.of(APPDOMAIN, "4");
         assertThat(processor.process(configuration, context2),
-                Matchers.equalTo(NONE));
+                equalTo(NONE));
 
     }
 

--- a/src/test/java/org/zalando/baigan/service/github/GitCacheLoaderTest.java
+++ b/src/test/java/org/zalando/baigan/service/github/GitCacheLoaderTest.java
@@ -5,24 +5,22 @@ import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.commons.codec.binary.Base64;
 import org.eclipse.egit.github.core.RepositoryContents;
 import org.eclipse.egit.github.core.service.ContentsService;
-import org.hamcrest.Matchers;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.zalando.baigan.model.Configuration;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
 import java.security.MessageDigest;
 import java.util.Map;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.eq;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class GitCacheLoaderTest {
 
     private String testConfiguration1 = "[{ \"alias\": \"express.feature.toggle\", \"description\": \"Feature toggle\", \"defaultValue\": false, \"conditions\": [   {   "
@@ -44,7 +42,7 @@ public class GitCacheLoaderTest {
         final GitCacheLoader loader = new GitCacheLoader(config,
                 contentService);
 
-        when(contentService.getContents(anyObject(),
+        when(contentService.getContents(any(),
                 eq("staging.json"),
                 eq("master")))
                 .thenReturn(ImmutableList
@@ -66,7 +64,7 @@ public class GitCacheLoaderTest {
         final GitCacheLoader loader = new GitCacheLoader(config,
                 contentService);
 
-        when(contentService.getContents(anyObject(),
+        when(contentService.getContents(any(),
                 eq("staging.json"),
                 eq("master")))
                 .thenReturn(ImmutableList
@@ -76,7 +74,7 @@ public class GitCacheLoaderTest {
         assertThat(configurations.size(), equalTo(1));
         assertThat(configurations.get("express.feature.toggle"), notNullValue());
 
-        when(contentService.getContents(anyObject(),
+        when(contentService.getContents(any(),
                 eq("staging.json"),
                 eq("master")))
                 .thenReturn(ImmutableList
@@ -87,7 +85,7 @@ public class GitCacheLoaderTest {
 
         final Map<String, Configuration> configurations2 = configurations2Future
                 .get();
-        assertThat(configurations2, Matchers.not(configurations));
+        assertThat(configurations2, not(configurations));
 
         assertThat(configurations2.size(), equalTo(2));
         assertThat(configurations.get("express.feature.toggle"), notNullValue());
@@ -104,7 +102,7 @@ public class GitCacheLoaderTest {
 
         final GitCacheLoader loader = new GitCacheLoader(config, contentService);
 
-        when(contentService.getContents(anyObject(),
+        when(contentService.getContents(any(),
                 eq("staging.json"),
                 eq("master")))
                 .thenReturn(ImmutableList
@@ -112,7 +110,7 @@ public class GitCacheLoaderTest {
 
         final Map<String, Configuration> configurations1 = loader.load("staging.json");
 
-        when(contentService.getContents(anyObject(),
+        when(contentService.getContents(any(),
                 eq("staging.json"),
                 eq("master")))
                 .thenReturn(ImmutableList
@@ -135,7 +133,7 @@ public class GitCacheLoaderTest {
         final GitCacheLoader loader = new GitCacheLoader(config, contentService);
 
         when(
-                contentService.getContents(anyObject(),
+                contentService.getContents(any(),
                         eq("staging.json"),
                         eq("master")))
                 .thenReturn(ImmutableList
@@ -149,7 +147,7 @@ public class GitCacheLoaderTest {
 
         //throw exception on retrieval
         doThrow(new IOException())
-                .when(contentService).getContents(anyObject(),
+                .when(contentService).getContents(any(),
                 eq("staging.json"),
                 eq("master"));
 


### PR DESCRIPTION
Updating dependencies to latest major versions. Spring is upgraded only from 4 to 5 to simplify migration and have updated dependencies also for those clients that are not on Spring 6 already. For the same reason, AWS SDK remains on version 1.

Code changes were required due to the upgrade to Junit 5. No logic was changed.