### PR TITLE
Release Script Adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## [Unreleased](https://github.com/zalando-stups/baigan-config/tree/HEAD)
+## [0.19.2](https://github.com/zalando-stups/baigan-config/tree/0.19.2)
 
-[Full Changelog](https://github.com/zalando-stups/baigan-config/compare/0.19.1...HEAD)
+[Full Changelog](https://github.com/zalando-stups/baigan-config/compare/0.19.1...0.19.2)
 
 **Merged pull requests:**
 

--- a/release.sh
+++ b/release.sh
@@ -15,7 +15,7 @@ next=$(semver "${release}" -i minor)
 ./mvnw versions:set -D newVersion="${release}"
 
 docker run -it --rm -e CHANGELOG_GITHUB_TOKEN -v "$(pwd)":/usr/local/src/your-app \
-    githubchangeloggenerator/github-changelog-generator -u zalando-stups -p baigan-config
+    githubchangeloggenerator/github-changelog-generator -u zalando-stups -p baigan-config --future-release ${release}
 
 git commit -am "Release ${release}"
 


### PR DESCRIPTION
Using the `--future-release` parameter of `github-changelog-generator` to have the new `CHANGELOG` entry be part of the ongoing release / tag.