### PR TITLE
use spring facilities for interface scanning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,12 +153,6 @@
             <version>${slf4j.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.reflections</groupId>
-            <artifactId>reflections</artifactId>
-            <version>0.10.2</version>
-        </dependency>
-
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/org/zalando/baigan/proxy/ConfigurationBeanDefinitionRegistrar.java
+++ b/src/main/java/org/zalando/baigan/proxy/ConfigurationBeanDefinitionRegistrar.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2015 Zalando SE (http://tech.zalando.com)
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,22 +16,25 @@
 
 package org.zalando.baigan.proxy;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import org.reflections.Reflections;
+import com.google.common.collect.Lists;
+import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.GenericBeanDefinition;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.core.type.filter.AnnotationTypeFilter;
 import org.springframework.util.StringUtils;
 import org.zalando.baigan.annotation.BaiganConfig;
 import org.zalando.baigan.annotation.ConfigurationServiceScan;
 
-import com.google.common.collect.Lists;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * ImportBeanDefinitionRegistrar implementation that finds the
@@ -75,25 +78,61 @@ public class ConfigurationBeanDefinitionRegistrar
     }
 
     private void createAndRegisterBeanDefinitions(final Set<String> packages,
-            final BeanDefinitionRegistry registry) {
+                                                  final BeanDefinitionRegistry registry) {
+
+        final ClassPathScanningCandidateComponentProvider scanner = new ClassPathScanningCandidateInterfaceProvider();
+        scanner.addIncludeFilter(new AnnotationTypeFilter(BaiganConfig.class));
+
         for (final String singlePackage : packages) {
-
-            final Set<Class<?>> configServiceInterfaces = new Reflections(
-                    singlePackage).getTypesAnnotatedWith(BaiganConfig.class);
-
-            for (final Class<?> interfaceToImplement : configServiceInterfaces) {
-                final BeanDefinitionBuilder builder = BeanDefinitionBuilder
-                        .genericBeanDefinition(
-                                ConfigurationServiceBeanFactory.class);
-                builder.addPropertyValue("candidateInterface",
-                        interfaceToImplement);
-
-                final String factoryBeanName = interfaceToImplement.getName()
-                        + "BaiganProxyConfigurationFactoryBean";
-                registry.registerBeanDefinition(factoryBeanName,
-                        builder.getBeanDefinition());
+            final Set<BeanDefinition> candidates = scanner.findCandidateComponents(singlePackage);
+            for (BeanDefinition definition : candidates) {
+                if (definition instanceof GenericBeanDefinition) {
+                    final GenericBeanDefinition genericDefinition = (GenericBeanDefinition) definition;
+                    registerAsBean(registry, genericDefinition);
+                } else {
+                    throw new IllegalStateException(
+                        String.format(
+                            "Unable to read required metadata of configuration candidate [%s]",
+                            definition
+                        )
+                    );
+                }
             }
+        }
+    }
 
+    private void registerAsBean(final BeanDefinitionRegistry registry, final GenericBeanDefinition genericDefinition) {
+        try {
+            final Class<?> interfaceToImplement = genericDefinition.resolveBeanClass(
+                registry.getClass().getClassLoader()
+            );
+            registerAsBean(registry, interfaceToImplement);
+        } catch (final ClassNotFoundException e) {
+            throw new IllegalStateException("Unable to register annotated interface as configuration bean", e);
+        }
+    }
+
+    private void registerAsBean(final BeanDefinitionRegistry registry, final Class<?> interfaceToImplement) {
+        final BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(
+            ConfigurationServiceBeanFactory.class
+        );
+        builder.addPropertyValue("candidateInterface", interfaceToImplement);
+
+        final String factoryBeanName = interfaceToImplement.getName() + "BaiganProxyConfigurationFactoryBean";
+        registry.registerBeanDefinition(factoryBeanName, builder.getBeanDefinition());
+    }
+
+    private static class ClassPathScanningCandidateInterfaceProvider
+        extends ClassPathScanningCandidateComponentProvider {
+
+        public ClassPathScanningCandidateInterfaceProvider() {
+            super(false);
+        }
+
+        @Override
+        protected boolean isCandidateComponent(AnnotatedBeanDefinition beanDefinition) {
+            final AnnotationMetadata metadata = beanDefinition.getMetadata();
+            return metadata.isIndependent() && metadata.isInterface();
         }
     }
 

--- a/src/test/java/org/zalando/baigan/AnnotationBeanRegistrationIT.java
+++ b/src/test/java/org/zalando/baigan/AnnotationBeanRegistrationIT.java
@@ -1,0 +1,45 @@
+package org.zalando.baigan;
+
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.zalando.baigan.annotation.ConfigurationServiceScan;
+import org.zalando.baigan.fixture.SomeConfiguration;
+import org.zalando.baigan.service.ConfigurationRepository;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {AnnotationBeanRegistrationIT.TestContext.class})
+public class AnnotationBeanRegistrationIT {
+
+    @Configuration
+    @ComponentScan(basePackageClasses = BaiganSpringContext.class)
+    @ConfigurationServiceScan(basePackages = "org.zalando.baigan.fixture")
+    static class TestContext {
+        @Bean
+        ConfigurationRepository configurationRepository() {
+            return mock(ConfigurationRepository.class);
+        }
+    }
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Test
+    void shouldRegisterAnnotatedConfigurationAsBean() {
+        final SomeConfiguration myBean = context.getBean(SomeConfiguration.class);
+        assertThat(myBean, is(not(nullValue())));
+    }
+}

--- a/src/test/java/org/zalando/baigan/fixture/SomeConfiguration.java
+++ b/src/test/java/org/zalando/baigan/fixture/SomeConfiguration.java
@@ -1,0 +1,8 @@
+package org.zalando.baigan.fixture;
+
+import org.zalando.baigan.annotation.BaiganConfig;
+
+@BaiganConfig
+public interface SomeConfiguration {
+    String someValue();
+}


### PR DESCRIPTION
* remove dependency on reflections library
* use built-in facilities for class-path scanning
* fail hard if scanning encounters issues

With https://github.com/ronmamo/reflections/issues/373 the core functionality of this library is broken as - depending on the used JDK/JRE - annotated configuration interfaces are not registered as beans since https://github.com/zalando-stups/baigan-config/pull/63. The tricky part is that this (mis-)behavior does not occur when application code is being executed by a test runner or alike, only in production.