### PR TITLE
builder for FileSystemConfigurationRepository

### DIFF
--- a/src/main/java/org/zalando/baigan/service/FileSystemConfigurationRepository.java
+++ b/src/main/java/org/zalando/baigan/service/FileSystemConfigurationRepository.java
@@ -35,7 +35,7 @@ public class FileSystemConfigurationRepository extends AbstractConfigurationRepo
     private final String fileName;
 
 
-    public FileSystemConfigurationRepository(final String fileName, long refreshIntervalInSeconds) {
+    FileSystemConfigurationRepository(final String fileName, long refreshIntervalInSeconds) {
         this.fileName = fileName;
 
         cachedConfigurations = CacheBuilder.newBuilder()

--- a/src/main/java/org/zalando/baigan/service/FileSystemConfigurationRepositoryBuilder.java
+++ b/src/main/java/org/zalando/baigan/service/FileSystemConfigurationRepositoryBuilder.java
@@ -1,0 +1,36 @@
+package org.zalando.baigan.service;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A builder to construct a {@link FileSystemConfigurationRepository}.
+ * <p>
+ * Requires that at least {@link FileSystemConfigurationRepository::filePath} is specified.
+ */
+public class FileSystemConfigurationRepositoryBuilder {
+
+    private String filePath;
+    private long refreshIntervalInSeconds = 60L;
+
+    /**
+     * @param filePath The path to the file that contains the configuration data.
+     */
+    public FileSystemConfigurationRepositoryBuilder fileName(String filePath) {
+        this.filePath = filePath;
+        return this;
+    }
+
+    /**
+     * @param refreshIntervalInSeconds The number of seconds between the starts of subsequent runs to refresh
+     *                                 the configuration.
+     */
+    public FileSystemConfigurationRepositoryBuilder refreshIntervalInSeconds(long refreshIntervalInSeconds) {
+        this.refreshIntervalInSeconds = refreshIntervalInSeconds;
+        return this;
+    }
+
+    public FileSystemConfigurationRepository build() {
+        requireNonNull(filePath, "filePath must not be null");
+        return new FileSystemConfigurationRepository(filePath, refreshIntervalInSeconds);
+    }
+}

--- a/src/main/java/org/zalando/baigan/service/aws/S3ConfigurationRepositoryBuilder.java
+++ b/src/main/java/org/zalando/baigan/service/aws/S3ConfigurationRepositoryBuilder.java
@@ -9,6 +9,12 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+/**
+ * A builder to construct a {@link S3ConfigurationRepository}.
+ * <p>
+ * Requires that at least {@link S3ConfigurationRepositoryBuilder::bucketName} and
+ * {@link S3ConfigurationRepositoryBuilder::key} are specified.
+ */
 public class S3ConfigurationRepositoryBuilder {
 
     private ScheduledThreadPoolExecutor executor;
@@ -55,7 +61,8 @@ public class S3ConfigurationRepositoryBuilder {
     }
 
     /**
-     * @param refreshIntervalInSeconds The number of seconds between the start of a run to refresh the configuration.
+     * @param refreshIntervalInSeconds The number of seconds between the starts of subsequent runs to refresh
+     *                                 the configuration
      */
     public S3ConfigurationRepositoryBuilder refreshIntervalInSeconds(final long refreshIntervalInSeconds) {
         this.refreshIntervalInSeconds = refreshIntervalInSeconds;


### PR DESCRIPTION
This commit adds a builder for the FileSystemConfigurationRepository to simplify future refactorings of the FileSystemConfigurationRepository and hiding potential future complexity of the construction of this class.

This was triggered by the discussion https://github.com/zalando-stups/baigan-config/pull/77#discussion_r1345770440