### PR TITLE
end-2-end test for EtcdConfigurationRepository

### DIFF
--- a/src/main/java/org/zalando/baigan/etcd/service/EtcdClient.java
+++ b/src/main/java/org/zalando/baigan/etcd/service/EtcdClient.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2015 Zalando SE (http://tech.zalando.com)
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/org/zalando/baigan/e2e/configs/SomeConfiguration.java
+++ b/src/test/java/org/zalando/baigan/e2e/configs/SomeConfiguration.java
@@ -2,8 +2,11 @@ package org.zalando.baigan.e2e.configs;
 
 import org.zalando.baigan.annotation.BaiganConfig;
 
+import java.util.List;
+
 @BaiganConfig
 public interface SomeConfiguration {
     String someValue();
     Boolean isThisTrue();
+    List<String> configList();
 }

--- a/src/test/java/org/zalando/baigan/e2e/etcdrepo/EtcdConfigurationRepositoryEnd2EndIT.java
+++ b/src/test/java/org/zalando/baigan/e2e/etcdrepo/EtcdConfigurationRepositoryEnd2EndIT.java
@@ -1,0 +1,102 @@
+package org.zalando.baigan.e2e.etcdrepo;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import org.zalando.baigan.BaiganSpringContext;
+import org.zalando.baigan.annotation.ConfigurationServiceScan;
+import org.zalando.baigan.e2e.configs.SomeConfiguration;
+import org.zalando.baigan.etcd.service.EtcdClient;
+import org.zalando.baigan.service.EtcdConfigurationRepository;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.nullValue;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {EtcdConfigurationRepositoryEnd2EndIT.RepoConfig.class})
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class EtcdConfigurationRepositoryEnd2EndIT {
+
+    @Autowired
+    private SomeConfiguration someConfiguration;
+    @Autowired
+    private GenericContainer<?> etcd;
+
+    private static final HttpClient client = HttpClient.newHttpClient();
+
+    @Test
+    public void givenEtcdConfiguration_whenKeyIsSetInEtcd_shouldProvideValueAsConfig() {
+        assertThat(someConfiguration.someValue(), nullValue());
+        setKeyInEtcd("some.configuration.some.value", "{\"alias\": \"some.configuration.some.value\", \"defaultValue\": \"some value\"}");
+        setKeyInEtcd("some.configuration.config.list", "{ \"alias\": \"some.configuration.config.list\", \"defaultValue\": [\"A\",\"B\"]}");
+        assertThat(someConfiguration.someValue(), equalTo("some value"));
+        assertThat(someConfiguration.configList(), equalTo(List.of("A", "B")));
+    }
+
+    private void setKeyInEtcd(final String key, final String value) {
+        final String url = "http://localhost:" + etcd.getMappedPort(2379) + "/v2/keys/" + key;
+        final String jsonPayload = "value=" + value;
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .PUT(HttpRequest.BodyPublishers.ofString(jsonPayload))
+                .build();
+        try {
+            final HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            assertThat(response.statusCode(), lessThan(300));
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @ConfigurationServiceScan(basePackages = "org.zalando.baigan.e2e.configs")
+    @Testcontainers
+    @ComponentScan(basePackageClasses = {BaiganSpringContext.class})
+    static class RepoConfig {
+
+        @Bean
+        EtcdConfigurationRepository configurationRepository(GenericContainer<?> etcd) {
+            return new EtcdConfigurationRepository(new EtcdClient("http://localhost:" + etcd.getMappedPort(2379)));
+        }
+
+        @Container
+        @SuppressWarnings("resource")
+        private static final GenericContainer<?> etcd = new GenericContainer<>(
+                DockerImageName.parse("quay.io/coreos/etcd:v2.3.8")
+        ).withExposedPorts(2379, 2380, 4001)
+                .withCommand(
+                        "-name", "node1",
+                        "-advertise-client-urls", "http://192.168.12.50:2379,http://192.168.12.50:4001",
+                        "-listen-client-urls", "http://0.0.0.0:2379,http://0.0.0.0:4001",
+                        "-initial-advertise-peer-urls", "http://192.168.12.50:2380",
+                        "-listen-peer-urls", "http://0.0.0.0:2380",
+                        "-initial-cluster-token", "etcd-cluster-1",
+                        "-initial-cluster", "node1=http://192.168.12.50:2380",
+                        "-initial-cluster-state", "new"
+                );
+
+        @Bean
+        public GenericContainer<?> etcd() {
+            etcd.start();
+            return etcd;
+        }
+    }
+}

--- a/src/test/java/org/zalando/baigan/e2e/filerepo/FileSystemConfigurationRepositoryEnd2EndIT.java
+++ b/src/test/java/org/zalando/baigan/e2e/filerepo/FileSystemConfigurationRepositoryEnd2EndIT.java
@@ -18,6 +18,7 @@ import org.zalando.baigan.service.FileSystemConfigurationRepositoryBuilder;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -46,11 +47,13 @@ public class FileSystemConfigurationRepositoryEnd2EndIT {
 
         Files.writeString(configFile, "[{ \"alias\": \"some.non.existing.config\", \"defaultValue\": \"an irrelevant value\"}," +
                 "{ \"alias\": \"some.configuration.is.this.true\", \"defaultValue\": true}, " +
-                "{ \"alias\": \"some.configuration.some.value\", \"defaultValue\": \"some value\"}]"
+                "{ \"alias\": \"some.configuration.some.value\", \"defaultValue\": \"some value\"}," +
+                "{ \"alias\": \"some.configuration.config.list\", \"defaultValue\": [\"A\",\"B\"]}]"
         );
         Thread.sleep(1100);
         assertThat(someConfiguration.isThisTrue(), equalTo(true));
         assertThat(someConfiguration.someValue(), equalTo("some value"));
+        assertThat(someConfiguration.configList(), equalTo(List.of("A", "B")));
     }
 
     @Test

--- a/src/test/java/org/zalando/baigan/e2e/s3repo/S3ConfigurationRepositoryEnd2EndIT.java
+++ b/src/test/java/org/zalando/baigan/e2e/s3repo/S3ConfigurationRepositoryEnd2EndIT.java
@@ -30,6 +30,7 @@ import org.zalando.baigan.service.aws.S3ConfigurationRepository;
 import org.zalando.baigan.service.aws.S3ConfigurationRepositoryBuilder;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -74,15 +75,17 @@ public class S3ConfigurationRepositoryEnd2EndIT {
                 S3_CONFIG_KEY,
                 "[{ \"alias\": \"some.non.existing.config\", \"defaultValue\": \"some irrelevant value\"}," +
                         "{ \"alias\": \"some.configuration.is.this.true\", \"defaultValue\": true}, " +
-                        "{ \"alias\": \"some.configuration.some.value\", \"defaultValue\": \"some value\"}]"
+                        "{ \"alias\": \"some.configuration.some.value\", \"defaultValue\": \"some value\"}, " +
+                        "{ \"alias\": \"some.configuration.config.list\", \"defaultValue\": [\"A\",\"B\"]}]"
         );
         Thread.sleep(1100);
         assertThat(someConfiguration.isThisTrue(), equalTo(true));
         assertThat(someConfiguration.someValue(), equalTo("some value"));
+        assertThat(someConfiguration.configList(), equalTo(List.of("A", "B")));
     }
 
     @Test
-    public void givenS3Configuration_whenTheS3FileIsUpdatedWithInvalidConfig_thenTheConfigurationIsNotUpdated() throws InterruptedException, IOException {
+    public void givenS3Configuration_whenTheS3FileIsUpdatedWithInvalidConfig_thenTheConfigurationIsNotUpdated() throws InterruptedException {
         s3.putObject(
                 S3_CONFIG_BUCKET,
                 S3_CONFIG_KEY,


### PR DESCRIPTION
This commit adds an end-2-end test for the EtcdConfigurationRepository to prepare for a later PR that refactors the deserialization of configs.

Related to #77 