### PR TITLE
Fix Javadoc Build

### DIFF
--- a/src/main/java/org/zalando/baigan/model/Condition.java
+++ b/src/main/java/org/zalando/baigan/model/Condition.java
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *
  * Represents a rule/condition that if met
  *
- * @param <T>
+ * @param <T> type of the value
  *
  * @author mchand
  */

--- a/src/main/java/org/zalando/baigan/model/Equals.java
+++ b/src/main/java/org/zalando/baigan/model/Equals.java
@@ -24,7 +24,7 @@ import java.util.StringJoiner;
 
 /**
  * Implementation of ConditionType that evaluates to true if the context param
- * matches the configured value..
+ * matches the configured value.
  *
  * @author mchand
  *

--- a/src/main/java/org/zalando/baigan/model/In.java
+++ b/src/main/java/org/zalando/baigan/model/In.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Implementation of ConditionType that evaluates to true if the context param
- * matches the configured value..
+ * matches the configured value.
  *
  * @author mchand
  *

--- a/src/main/java/org/zalando/baigan/repository/ChainedConfigurationRepositoryBuilder.java
+++ b/src/main/java/org/zalando/baigan/repository/ChainedConfigurationRepositoryBuilder.java
@@ -8,7 +8,7 @@ import static org.springframework.util.Assert.notEmpty;
 /**
  * A builder to construct a {@link FileSystemConfigurationRepository}.
  * <p>
- * At least one repository has to be provided..
+ * At least one repository has to be provided.
  */
 public class ChainedConfigurationRepositoryBuilder {
 

--- a/src/main/java/org/zalando/baigan/repository/EtcdConfigurationRepositoryBuilder.java
+++ b/src/main/java/org/zalando/baigan/repository/EtcdConfigurationRepositoryBuilder.java
@@ -7,7 +7,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * A builder to construct an {@link EtcdConfigurationRepository}.
  * <p>
- * Requires that at least {@link EtcdConfigurationRepositoryBuilder::etcdUrl} is specified.
+ * Requires that at least {@link EtcdConfigurationRepositoryBuilder#etcdUrl(String)} is specified.
  */
 public class EtcdConfigurationRepositoryBuilder {
 

--- a/src/main/java/org/zalando/baigan/repository/FileSystemConfigurationRepositoryBuilder.java
+++ b/src/main/java/org/zalando/baigan/repository/FileSystemConfigurationRepositoryBuilder.java
@@ -7,7 +7,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * A builder to construct a {@link FileSystemConfigurationRepository}.
  * <p>
- * Requires that at least {@link FileSystemConfigurationRepository::filePath} is specified.
+ * Requires that at least {@link FileSystemConfigurationRepositoryBuilder#fileName(String)} is specified.
  */
 public class FileSystemConfigurationRepositoryBuilder {
 

--- a/src/main/java/org/zalando/baigan/repository/S3ConfigurationRepositoryBuilder.java
+++ b/src/main/java/org/zalando/baigan/repository/S3ConfigurationRepositoryBuilder.java
@@ -15,10 +15,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Builder class for an S3ConfigurationRepository.
  * <p>
- * Must specify non-null values for
- * - {@link S3ConfigurationRepositoryBuilder#bucketName}
- * - {@link S3ConfigurationRepositoryBuilder#key}
- * <p>
+ * Must specify non-null values for:
+ * <ul>
+ * <li>{@link S3ConfigurationRepositoryBuilder#bucketName(String)}
+ * <li>{@link S3ConfigurationRepositoryBuilder#key(String)}
+ * </ul>
  */
 public class S3ConfigurationRepositoryBuilder {
 


### PR DESCRIPTION
Before we can release a new version, we have to resolve the Javadoc errors on `link` references. I randomly fixed some other _warnings_ too. There are ~15 warnings on `warning: no @return` left for the future generation to resolve. 