### PR TITLE
specify refresh interval as duration

### DIFF
--- a/src/main/java/org/zalando/baigan/repository/FileSystemConfigurationRepository.java
+++ b/src/main/java/org/zalando/baigan/repository/FileSystemConfigurationRepository.java
@@ -15,11 +15,11 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 
 /**
  * A {@link ConfigurationRepository} implementation supporting a file on
@@ -36,12 +36,12 @@ public class FileSystemConfigurationRepository implements ConfigurationRepositor
     private final LoadingCache<String, Map<String, Configuration<?>>> cachedConfigurations;
     private final String fileName;
 
-    FileSystemConfigurationRepository(final String fileName, long refreshIntervalInSeconds, final ConfigurationParser configurationParser) {
+    FileSystemConfigurationRepository(final String fileName, Duration refreshInterval, final ConfigurationParser configurationParser) {
         this.fileName = fileName;
         this.configurationParser = configurationParser;
 
         cachedConfigurations = CacheBuilder.newBuilder()
-                .refreshAfterWrite(refreshIntervalInSeconds, TimeUnit.SECONDS)
+                .refreshAfterWrite(refreshInterval)
                 .build(new CacheLoader<>() {
                     @Override
                     public Map<String, Configuration<?>> load(String filename) {

--- a/src/main/java/org/zalando/baigan/repository/FileSystemConfigurationRepositoryBuilder.java
+++ b/src/main/java/org/zalando/baigan/repository/FileSystemConfigurationRepositoryBuilder.java
@@ -2,6 +2,8 @@ package org.zalando.baigan.repository;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.time.Duration;
+
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -12,7 +14,7 @@ import static java.util.Objects.requireNonNull;
 public class FileSystemConfigurationRepositoryBuilder {
 
     private String filePath;
-    private long refreshIntervalInSeconds = 60L;
+    private Duration refreshInterval = Duration.ofMinutes(1);
     private ObjectMapper objectMapper;
     private final ConfigurationParser configurationParser;
 
@@ -31,9 +33,11 @@ public class FileSystemConfigurationRepositoryBuilder {
     /**
      * @param refreshIntervalInSeconds The number of seconds between the starts of subsequent runs to refresh
      *                                 the configuration.
+     * <p>
+     * {@code @Deprecated} use {@link S3ConfigurationRepositoryBuilder#refreshInterval(Duration)} instead
      */
     public FileSystemConfigurationRepositoryBuilder refreshIntervalInSeconds(long refreshIntervalInSeconds) {
-        this.refreshIntervalInSeconds = refreshIntervalInSeconds;
+        this.refreshInterval = Duration.ofSeconds(refreshIntervalInSeconds);
         return this;
     }
 
@@ -45,6 +49,14 @@ public class FileSystemConfigurationRepositoryBuilder {
         return this;
     }
 
+    /**
+     * @param refreshInterval The interval between the starts of subsequent runs to refresh the configuration.
+     */
+    public FileSystemConfigurationRepositoryBuilder refreshInterval(Duration refreshInterval) {
+        this.refreshInterval = refreshInterval;
+        return this;
+    }
+
     public FileSystemConfigurationRepository build() {
         requireNonNull(filePath, "filePath must not be null");
 
@@ -52,6 +64,6 @@ public class FileSystemConfigurationRepositoryBuilder {
             configurationParser.setObjectMapper(objectMapper);
         }
 
-        return new FileSystemConfigurationRepository(filePath, refreshIntervalInSeconds, configurationParser);
+        return new FileSystemConfigurationRepository(filePath, refreshInterval, configurationParser);
     }
 }

--- a/src/main/java/org/zalando/baigan/repository/S3ConfigurationRepositoryBuilder.java
+++ b/src/main/java/org/zalando/baigan/repository/S3ConfigurationRepositoryBuilder.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import javax.annotation.Nonnull;
+import java.time.Duration;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
@@ -26,7 +27,7 @@ public class S3ConfigurationRepositoryBuilder {
     private ScheduledExecutorService executor;
     private AmazonS3 s3Client;
     private AWSKMS kmsClient;
-    private long refreshIntervalInSeconds = 60;
+    private Duration refreshInterval = Duration.ofMinutes(1);
     private String bucketName;
     private String key;
     private ObjectMapper objectMapper;
@@ -75,9 +76,12 @@ public class S3ConfigurationRepositoryBuilder {
     /**
      * @param refreshIntervalInSeconds The number of seconds between the starts of subsequent runs to refresh
      *                                 the configuration
+     * <p>
+     * {@code @Deprecated} use {@link S3ConfigurationRepositoryBuilder#refreshInterval(Duration)} instead
      */
+    @Deprecated
     public S3ConfigurationRepositoryBuilder refreshIntervalInSeconds(final long refreshIntervalInSeconds) {
-        this.refreshIntervalInSeconds = refreshIntervalInSeconds;
+        this.refreshInterval = Duration.ofSeconds(refreshIntervalInSeconds);
         return this;
     }
 
@@ -98,6 +102,14 @@ public class S3ConfigurationRepositoryBuilder {
         return this;
     }
 
+    /**
+     * @param refreshInterval The interval between the starts of subsequent runs to refresh the configuration.
+     */
+    public S3ConfigurationRepositoryBuilder refreshInterval(Duration refreshInterval) {
+        this.refreshInterval = refreshInterval;
+        return this;
+    }
+
     public S3ConfigurationRepository build() {
         if (executor == null) {
             executor = new ScheduledThreadPoolExecutor(1);
@@ -112,6 +124,6 @@ public class S3ConfigurationRepositoryBuilder {
             configurationParser.setObjectMapper(objectMapper);
         }
 
-        return new S3ConfigurationRepository(bucketName, key, refreshIntervalInSeconds, executor, s3Client, kmsClient, configurationParser);
+        return new S3ConfigurationRepository(bucketName, key, refreshInterval, executor, s3Client, kmsClient, configurationParser);
     }
 }

--- a/src/test/java/org/zalando/baigan/e2e/s3repo/S3ConfigurationRepositoryEnd2EndIT.java
+++ b/src/test/java/org/zalando/baigan/e2e/s3repo/S3ConfigurationRepositoryEnd2EndIT.java
@@ -30,6 +30,7 @@ import org.zalando.baigan.e2e.configs.SomeConfiguration;
 import org.zalando.baigan.repository.RepositoryFactory;
 import org.zalando.baigan.repository.S3ConfigurationRepository;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
@@ -46,6 +47,9 @@ public class S3ConfigurationRepositoryEnd2EndIT {
 
     public static final String S3_CONFIG_BUCKET = "some-bucket";
     public static final String S3_CONFIG_KEY = "some-key";
+
+    private static final Duration CONFIG_REFRESH_INTERVAL = Duration.ofMillis(100);
+    private static final long TIME_TO_WAIT_FOR_CONFIG_REFRESH = CONFIG_REFRESH_INTERVAL.plusMillis(100).toMillis();
 
     @Autowired
     private AmazonS3 s3;
@@ -69,7 +73,7 @@ public class S3ConfigurationRepositoryEnd2EndIT {
                 S3_CONFIG_KEY,
                 "[{\"alias\": \"some.configuration.some.value\", \"defaultValue\": \"some value\"}]"
         );
-        Thread.sleep(1100);
+        Thread.sleep(TIME_TO_WAIT_FOR_CONFIG_REFRESH);
         assertThat(someConfiguration.isThisTrue(), nullValue());
         assertThat(someConfiguration.someValue(), equalTo("some value"));
         assertThat(someConfiguration.someConfig(), nullValue());
@@ -84,7 +88,7 @@ public class S3ConfigurationRepositoryEnd2EndIT {
                         "{ \"alias\": \"some.configuration.some.value\", \"defaultValue\": \"some value\"}, " +
                         "{ \"alias\": \"some.configuration.config.list\", \"defaultValue\": [\"A\",\"B\"]}]"
         );
-        Thread.sleep(1100);
+        Thread.sleep(TIME_TO_WAIT_FOR_CONFIG_REFRESH);
         assertThat(someConfiguration.someConfig(), equalTo(new SomeConfigObject("a value")));
         assertThat(someConfiguration.isThisTrue(), equalTo(true));
         assertThat(someConfiguration.someValue(), equalTo("some value"));
@@ -99,7 +103,7 @@ public class S3ConfigurationRepositoryEnd2EndIT {
                 "[{\"alias\": \"some.configuration.is.this.true\", \"defaultValue\": true}, " +
                         "{\"alias\": \"some.configuration.some.value\", \"defaultValue\": \"some value\"}]"
         );
-        Thread.sleep(1100);
+        Thread.sleep(TIME_TO_WAIT_FOR_CONFIG_REFRESH);
         assertThat(someConfiguration.isThisTrue(), equalTo(true));
         assertThat(someConfiguration.someValue(), equalTo("some value"));
 
@@ -108,7 +112,7 @@ public class S3ConfigurationRepositoryEnd2EndIT {
                 S3_CONFIG_KEY,
                 "an: invalid\"} config"
         );
-        Thread.sleep(1100);
+        Thread.sleep(TIME_TO_WAIT_FOR_CONFIG_REFRESH);
         assertThat(someConfiguration.isThisTrue(), equalTo(true));
         assertThat(someConfiguration.someValue(), equalTo("some value"));
     }
@@ -141,7 +145,7 @@ public class S3ConfigurationRepositoryEnd2EndIT {
                     .key(S3_CONFIG_KEY)
                     .s3Client(amazonS3)
                     .kmsClient(kms)
-                    .refreshIntervalInSeconds(1)
+                    .refreshInterval(CONFIG_REFRESH_INTERVAL)
                     .executor(executorService)
                     .build();
         }


### PR DESCRIPTION
This commit stores the refresh interval for S3ConfigurationRepository and FileSystemConfigurationRepository as Duration object and adds corresponding methods to the builders. This allows specifying sub-second refresh intervals, which is particularly useful in tests.