### PR TITLE
Remove unused git client dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,12 +94,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.eclipse.mylyn.github</groupId>
-            <artifactId>org.eclipse.egit.github.core</artifactId>
-            <version>2.1.5</version>
-        </dependency>
-
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>


### PR DESCRIPTION
Since `GitConfigurationRepository` was removed in #78 the `org.eclipse.egit.github.core` dependency is also not needed anymore.