### PR TITLE
Remove JUnit4, use testcontainers bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,9 +52,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>com.amazonaws</groupId>
-                <artifactId>aws-java-sdk-bom</artifactId>
-                <version>${awssdk.version}</version>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${testcontainers.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -197,19 +197,30 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- A hack until testcontainers require JUnit4 -->
+        <!-- https://github.com/testcontainers/testcontainers-java/issues/970 -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit4-mock</artifactId>
+            <version>3.0.0.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>localstack</artifactId>
-            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/zalando/baigan/context/ConfigurationBeanDefinitionRegistrarTest.java
+++ b/src/test/java/org/zalando/baigan/context/ConfigurationBeanDefinitionRegistrarTest.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;

--- a/src/test/java/org/zalando/baigan/repository/ConfigurationParserTest.java
+++ b/src/test/java/org/zalando/baigan/repository/ConfigurationParserTest.java
@@ -20,7 +20,7 @@ import static java.util.Optional.empty;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 


### PR DESCRIPTION
This PR removes JUnit4 from the dependencies to avoid confusion with JUnit5 methods.
Testcontainers unfortunately still requires JUnit4 (see [this issue](https://github.com/testcontainers/testcontainers-java/issues/970)). A recommended workaround is to use [quarkus-junit4-mock](https://github.com/quarkusio/quarkus/tree/main/core/junit4-mock).

Also the PR introduces testcontainers-bom, because the project has 3 testcontainers dependency.
`aws-java-sdk-bom` was removed, because there is only one aws-s3 dependency, so the bom usage doesn't make sense.