### PR TITLE
Remove unused jackson modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,18 +100,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-guava</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jdk8</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
             <version>${spring.version}</version>

--- a/src/test/java/org/zalando/baigan/model/TestConfigurationSerialization.java
+++ b/src/test/java/org/zalando/baigan/model/TestConfigurationSerialization.java
@@ -17,7 +17,6 @@
 package org.zalando.baigan.model;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,7 +39,7 @@ public class TestConfigurationSerialization {
 
     @BeforeEach
     public void init() {
-        mapper = new ObjectMapper().registerModule(new GuavaModule());
+        mapper = new ObjectMapper();
         conditionsProcessor = new ConditionsProcessor();
 
     }


### PR DESCRIPTION
This PR removes unused jackson dependencies: `jackson-datatype-guava` and `jackson-datatype-jdk8`.

As far as I understood, if a library user wants to use custom classes for dynamic configuration properties, they can either provide a custom `ObjectMapper` (with all necessary configured modules), or use the default `ObjectMapper` without any modules (`new ObjectMapper()`). See [this codeblock](https://github.com/zalando-stups/baigan-config/blob/9274783355acb087ccf84f02707982ee9464a221/src/main/java/org/zalando/baigan/repository/ConfigurationParser.java#L38).

Therefore I don't see a reason to include additional jackson modules to baigan dependencies.