### PR TITLE
Spring 6 and 5 compatibility

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,6 +18,9 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        profile: ['', 'spring5']
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -25,9 +28,9 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
           cache: 'maven'
       - name: Compile
         run: ./mvnw clean javadoc:javadoc package -DskipTests
       - name: Test
-        run: ./mvnw verify -P integration-test -B
+        run: ./mvnw verify -P "${{ matrix.profile }}" -P integration-test -B

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Build Status](https://github.com/zalando-stups/baigan-config/workflows/build/badge.svg)
 [![Maven Central](https://img.shields.io/maven-central/v/org.zalando/baigan-config.svg)](https://maven-badges.herokuapp.com/maven-central/org.zalando/baigan-config)
 
-Baigan configuration is an easy to use configuration framework for [Spring](https://spring.io/) based applications.
+Baigan configuration is an easy-to-use configuration framework for [Spring](https://spring.io/) based applications.
 
 What makes Baigan a rockstar configuration framework ?
 
@@ -14,8 +14,8 @@ What makes Baigan a rockstar configuration framework ?
 	* AWS S3
 
 ## Prerequisites
-- Java 11
-- Spring framework
+- Java 17
+- Spring Framework 6 (backwards compatible to 5)
 - AWS SDK
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ What makes Baigan a rockstar configuration framework ?
 	* AWS S3
 
 ## Prerequisites
-- Java 17
+- Java 17+
 - Spring Framework 6 (backwards compatible to 5)
 - AWS SDK
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,9 +38,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>11</maven.compiler.release> <!-- ensure Spring 5 compatibility -->
+        <spring6.version>6.1.2</spring6.version>
+        <spring5.version>5.3.31</spring5.version>
+        <spring.version>${spring6.version}</spring.version>
         <jackson.version>2.15.1</jackson.version>
         <junit.version>5.9.3</junit.version>
-        <spring.version>5.3.27</spring.version>
         <guava.version>32.0.1-jre</guava.version>
         <slf4j.version>2.0.7</slf4j.version>
         <mockito.version>5.3.1</mockito.version>
@@ -82,10 +85,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.11.0</version>
-                    <configuration>
-                        <source>11</source>
-                        <target>11</target>
-                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -227,6 +226,12 @@
     </dependencies>
 
     <profiles>
+        <profile>
+            <id>spring5</id>
+            <properties>
+                <spring.version>${spring5.version}</spring.version>
+            </properties>
+        </profile>
         <profile>
             <id>release</id>
             <build>


### PR DESCRIPTION
Fixes #75 

* upgrade base Spring dependency to Spring 6
* backwards compatibility with Spring 5 (via building against Java 11)
* run build and tests against both Spring 6 and 5

We also tested the compatibility successfully with two little example applications.