### PR TITLE
Add a warning for concurrent access during context initialisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ public class ExpressServiceImpl implements ExpressService {
     }
 }
 ```
+> [!CAUTION]
+> Due to the way bean access is managed, concurrent use of Baigan's proxies from multiple threads during the early stages of Spring context initialization can result in concurrency issues, including the potential for deadlock. 
+> To mitigate this risk, it is advisable to refrain from accessing Baigan's proxies until the Spring context has been initialized.
+
 
 #### Provide a configuration repository
 


### PR DESCRIPTION
**Context**
We noticed deadlock in Spring boot application startup caused by the lock in obtaining beans from the application context. This was due to the nature of Baigan's proxy logic that needs to be accessed concurrently after the Spring context initialisation complete.

This PR adds disclaimer into the Readme about the negative effects of concurrent use of Baigan proxies during the early stages of Spring context initialisation.